### PR TITLE
Add README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# OctoAcme Project Management Docs (README)
+
+## Summary of Project Management Processes
+
+OctoAcme employs a structured, lifecycle-based project management methodology designed to prioritize customer value, iterative delivery, and clear team ownership. The process is organized into five high-level phases: **Initiation**, **Planning**, **Execution**, **Release**, and **Close & Retrospective**. During Initiation, the business need is validated, key stakeholders align on metrics and objectives, and lightweight planning artifacts are created. The Planning phase translates goals into actionable backlogs—work items are prioritized, estimated, and defined with clear acceptance criteria and "Definition of Done." Execution emphasizes small, testable increments, daily and weekly team syncs, and continuous risk monitoring via a shared board and risk register, with regular demos and escalating blocker paths.
+
+Communication and roles are clearly delineated: **Project Managers** coordinate delivery and risk, **Product Managers** define priorities and outcomes, **Developers** implement and test, and **QA** validates requirements. Stakeholder communication follows a weekly and monthly cadence, with transparent status reporting and milestone reviews. Release and deployment processes are standardized with pre-release checks, automated pipelines, smoke tests, and rollback/incident playbooks. Finally, after each release or major milestone, structured retrospectives are held to capture lessons learned and feed improvement actions directly into the project backlog—fostering a culture of psychological safety and repeatable success.
+
+## Quick Links to Process Docs
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)


### PR DESCRIPTION
Addresses issue #2 — creates a central README for discoverability and onboarding